### PR TITLE
Moving VSCode from `TRIAL` to `ADOPT`

### DIFF
--- a/Qube TechRadar.csv
+++ b/Qube TechRadar.csv
@@ -1,6 +1,6 @@
 name,ring,quadrant,isNew,description
 Go,Adopt,languages-and-frameworks,FALSE,"Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
-Visual Studio Code,Adopt,Tools,TRUE,"Visual Studio Code is an opensource, lightweight, cross-platform code editor for most programming languages & files, with amazing extensions and built-in space for terminals"
+Visual Studio Code,Adopt,Tools,TRUE,"Visual Studio Code is an open-source, cross-platform code editor for most programming languages & files, with amazing extensions and built-in space for terminals"
 AWS DevOps,Trial,Platforms,FALSE,"AWS DevOps provides services to simplify provisioning and managing infrastructure, deploying application code, automating software release processes, and monitoring your application and infrastructure performance."
 Microservices,Adopt,Techniques,FALSE,"Microservices arranges an application as a collection of loosely coupled services."
 Yocto,Adopt,Tools,FALSE,"The Yocto Project (YP) is an open source collaboration project that helps developers create custom Linux-based systems regardless of the hardware architecture."

--- a/Qube TechRadar.csv
+++ b/Qube TechRadar.csv
@@ -1,6 +1,6 @@
 name,ring,quadrant,isNew,description
 Go,Adopt,languages-and-frameworks,FALSE,"Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
-Visual Studio Code,Trial,Tools,FALSE,"Visual Studio Code is an opensource, lightweight, cross-platform code editor for most programming languages & files, with amazing extensions and built-in space for terminals"
+Visual Studio Code,Adopt,Tools,TRUE,"Visual Studio Code is an opensource, lightweight, cross-platform code editor for most programming languages & files, with amazing extensions and built-in space for terminals"
 AWS DevOps,Trial,Platforms,FALSE,"AWS DevOps provides services to simplify provisioning and managing infrastructure, deploying application code, automating software release processes, and monitoring your application and infrastructure performance."
 Microservices,Adopt,Techniques,FALSE,"Microservices arranges an application as a collection of loosely coupled services."
 Yocto,Adopt,Tools,FALSE,"The Yocto Project (YP) is an open source collaboration project that helps developers create custom Linux-based systems regardless of the hardware architecture."

--- a/Qube TechRadar.csv
+++ b/Qube TechRadar.csv
@@ -1,6 +1,6 @@
 name,ring,quadrant,isNew,description
 Go,Adopt,languages-and-frameworks,FALSE,"Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
-Visual Studio Code,Trial,Tools,FALSE,"Visual Studio Code is an opensource, lightweight, cross-platform editor for most programming languages & files, with amazing extensions and built-in space for terminals"
+Visual Studio Code,Trial,Tools,FALSE,"Visual Studio Code is an opensource, lightweight, cross-platform code editor for most programming languages & files, with amazing extensions and built-in space for terminals"
 AWS DevOps,Trial,Platforms,FALSE,"AWS DevOps provides services to simplify provisioning and managing infrastructure, deploying application code, automating software release processes, and monitoring your application and infrastructure performance."
 Microservices,Adopt,Techniques,FALSE,"Microservices arranges an application as a collection of loosely coupled services."
 Yocto,Adopt,Tools,FALSE,"The Yocto Project (YP) is an open source collaboration project that helps developers create custom Linux-based systems regardless of the hardware architecture."

--- a/Qube TechRadar.csv
+++ b/Qube TechRadar.csv
@@ -1,6 +1,6 @@
 name,ring,quadrant,isNew,description
 Go,Adopt,languages-and-frameworks,FALSE,"Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
-Visual Studio Code,Trial,Tools,FALSE,"Visual Studio Code is a code editor redefined and optimized for building and debugging modern web and cloud applications."
+Visual Studio Code,Trial,Tools,FALSE,"Visual Studio Code is an opensource, lightweight, cross-platform editor for most programming languages & files, with amazing extensions"
 AWS DevOps,Trial,Platforms,FALSE,"AWS DevOps provides services to simplify provisioning and managing infrastructure, deploying application code, automating software release processes, and monitoring your application and infrastructure performance."
 Microservices,Adopt,Techniques,FALSE,"Microservices arranges an application as a collection of loosely coupled services."
 Yocto,Adopt,Tools,FALSE,"The Yocto Project (YP) is an open source collaboration project that helps developers create custom Linux-based systems regardless of the hardware architecture."

--- a/Qube TechRadar.csv
+++ b/Qube TechRadar.csv
@@ -1,6 +1,6 @@
 name,ring,quadrant,isNew,description
 Go,Adopt,languages-and-frameworks,FALSE,"Go is an open source programming language that makes it easy to build simple, reliable, and efficient software."
-Visual Studio Code,Trial,Tools,FALSE,"Visual Studio Code is an opensource, lightweight, cross-platform editor for most programming languages & files, with amazing extensions"
+Visual Studio Code,Trial,Tools,FALSE,"Visual Studio Code is an opensource, lightweight, cross-platform editor for most programming languages & files, with amazing extensions and built-in space for terminals"
 AWS DevOps,Trial,Platforms,FALSE,"AWS DevOps provides services to simplify provisioning and managing infrastructure, deploying application code, automating software release processes, and monitoring your application and infrastructure performance."
 Microservices,Adopt,Techniques,FALSE,"Microservices arranges an application as a collection of loosely coupled services."
 Yocto,Adopt,Tools,FALSE,"The Yocto Project (YP) is an open source collaboration project that helps developers create custom Linux-based systems regardless of the hardware architecture."


### PR DESCRIPTION
I'm suggesting that we move VSCode from `TRIAL` to `ADOPT`.

**Reason** - Visual Studio Code is an opensource, lightweight, cross-platform editor for most programming languages & files, with amazing extensions and built-in space for terminals.

(also to see how the PR discussion would go for a change like this..  :D)